### PR TITLE
Enable race detection in unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ build-bin:
 	./build.sh
 
 test: build-bin # Tests need sudo due to network interfaces creation
-	sudo -E bash -c "umask 0; PATH=${GOPATH}/bin:$(pwd)/bin:${PATH} go test ./bond/"
+	sudo -E bash -c "umask 0; PATH=${GOPATH}/bin:$(pwd)/bin:${PATH} go test -race ./bond/"


### PR DESCRIPTION
This change updates the Makefile to include the '-race' flag, enabling race detection during testing.